### PR TITLE
Adds up-front mode that requires env var arguments

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'sopell/up-front-mode'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: ./c_version
+        file: ./Dockerfile
+        push: true
+        platforms: linux/amd64, linux/arm64
+        tags: ghcr.io/${{ github.repository }}:c-latest

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -25,7 +25,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image
+    - name: Build and push c-version Docker image
       uses: docker/build-push-action@v6
       with:
         context: ./c_version/
@@ -33,3 +33,12 @@ jobs:
         push: true
         platforms: linux/amd64, linux/arm64
         tags: ghcr.io/${{ github.repository }}:c-latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: ./go_version/
+        file: ./go_version/Dockerfile
+        push: true
+        platforms: linux/amd64, linux/arm64
+        tags: ghcr.io/${{ github.repository }}:go-latest

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -28,8 +28,8 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:
-        context: ./c_version
-        file: ./Dockerfile
+        context: ./c_version/
+        file: ./c_version/Dockerfile
         push: true
         platforms: linux/amd64, linux/arm64
         tags: ghcr.io/${{ github.repository }}:c-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+c_version/cmadv
+c_version/*.o
+go_version/gomadv

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to allocate and de-allocate in a similar way to the go runtime.
 ## C Usage
 ```
 cd c_version
-gcc -o cmadv main.c
+make
 ./cmadv
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,59 @@
 # Memory Playgrounds
 
 Goal of these two programs is to allocate memory and free it in various ways.
-C is obviously much simpler than Go, and C version is making some rough attempt
-to allocate and de-allocate in a similar way to the go runtime.
+C version is making a rough attempt to allocate and de-allocate in a similar way to the go runtime.
+
+## Modes
+There are 2 modes that this program operates in.
+### Interactive
+The default (ie, without arguments) is to run in "interactive" mode.
+This version starts and waits for keyboard input.
+
+See the printed help messages for the commands accepted.
+
+### Up-front
+There are 3 arguments taken via env var, and each must be specified and valid in
+order for the program to run in "up-front" mode.
+
+- `NUM_ALLOCS` - (int) - The number of allocations to perform of the given size
+- `ALLOC_SIZE` - (int) - The number of bytes to request during each allocation
+- `INITIAL_SLEEP` - (int) - The number of seconds to sleep _before_ allocating
+  anything. This can be useful to determine a "baseline" for the process.
+
+Both the C and Go version take the same arguments.
 
 ## C Usage
+### Build
 ```
 cd c_version
 make
 ./cmadv
 ```
 
+### Run via docker
+```
+# To run in interactive mode
+docker run --rm -it ghcr.io/scottopell/madv:c-latest
+
+# To run in up-front mode
+docker run --rm -e ALLOC_SIZE=10000000 -e NUM_ALLOCS=5 -e INITIAL_SLEEP=5 ghcr.io/scottopell/madv:c-latest
+```
+
 ## Go Usage
+### Build
 ```
 cd go_version
-go build -o gomadv
+go build -o gomadv main.go
 ./gomadv
+```
+
+### Run via docker
+```
+# To run in interactive mode
+docker run --rm -it ghcr.io/scottopell/madv:c-latest
+
+# To run in up-front mode
+docker run --rm -e ALLOC_SIZE=10000000 -e NUM_ALLOCS=5 -e INITIAL_SLEEP=5 ghcr.io/scottopell/madv:go-latest
 ```
 
 ## Results
@@ -25,7 +63,7 @@ To "view the results" the idea is to check the OS level RSS reported.
 hwatch 'ps e -o "rss,vsz,pid" -p $(pidof gomadv)'
 ```
 
-In the C version, this appears to be pretty immediate and correctly reduces the
+In the C version, a free operation appears to be pretty immediate and correctly reduces the
 RSS.
 
 In the Go version, the RSS goes down immediately post `FreeOsMemory`.

--- a/c_version/Dockerfile
+++ b/c_version/Dockerfile
@@ -1,0 +1,20 @@
+FROM gcc:latest AS builder
+
+WORKDIR /app
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN make
+
+FROM ubuntu:latest
+
+WORKDIR /app
+
+# Copy the built application from the builder stage
+COPY --from=builder /app/cmadv /app/cmadv
+
+# Set the entrypoint
+ENTRYPOINT ["/app/cmadv"]
+

--- a/c_version/Makefile
+++ b/c_version/Makefile
@@ -1,0 +1,33 @@
+# Compiler
+CC = gcc
+
+# Compiler flags
+CFLAGS = -Wall -O2
+
+# Source files
+SRCS = $(wildcard *.c)
+
+# Object files
+OBJS = $(SRCS:.c=.o)
+
+# Executable name
+TARGET = cmadv
+
+# Default target to build the executable
+all: $(TARGET)
+
+# Link object files to create the executable
+$(TARGET): $(OBJS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS)
+
+# Compile source files into object files
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Clean up object files and the executable
+clean:
+	rm -f $(OBJS) $(TARGET)
+
+# Phony targets to avoid conflicts with file names
+.PHONY: all clean
+

--- a/c_version/main.c
+++ b/c_version/main.c
@@ -7,7 +7,6 @@
 #define DEFAULT_ALLOC_SIZE (8 * 1024 * 1024)
 
 static int q = 113;
-static int a = 95;
 static int f = 102;
 static int d = 100;
 

--- a/c_version/main.c
+++ b/c_version/main.c
@@ -1,7 +1,15 @@
 #include <stdio.h>
-#include <sys/mman.h>
 #include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <termios.h>
+
+#define DEFAULT_ALLOC_SIZE (8 * 1024 * 1024)
+
+static int q = 113;
+static int a = 95;
+static int f = 102;
+static int d = 100;
 
 // https://stackoverflow.com/a/19317368
 char getch(void) {
@@ -21,18 +29,49 @@ char getch(void) {
     return ch;
 }
 
-static int q = 113;
-static int a = 95;
-static int f = 102;
-static int d = 100;
+void up_front_mode(size_t alloc_size, int num_allocs, int initial_sleep) {
+    printf("Operating in special mode with %d allocations of %zu bytes each and an initial sleep of %d seconds.\n",
+           num_allocs, alloc_size, initial_sleep);
 
-int main() {
+    printf("Sleeping for %d seconds...\n", initial_sleep);
+    sleep(initial_sleep);
+
+    void *ptrs[num_allocs];
+
+    for (int i = 0; i < num_allocs; i++) {
+        ptrs[i] = mmap(0, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (ptrs[i] == MAP_FAILED) {
+            perror("Memory allocation failed");
+            exit(1);
+        }
+
+        for (size_t j = 0; j < alloc_size / sizeof(int); j++) {
+            ((int *)ptrs[i])[j] = 55;
+        }
+
+        printf("Allocated %p (size %zu) and dirtied it\n", ptrs[i], alloc_size);
+    }
+
+    // Sleep indefinitely until a signal is received
+    pause();
+
+    printf("Termination signal received. Cleaning up and exiting...\n");
+
+    for (int i = 0; i < num_allocs; i++) {
+        munmap(ptrs[i], alloc_size);
+    }
+}
+
+// Function to handle the interactive mode
+void interactive_mode() {
     printf("Press a to allocate more memory, f to MADV_FREE, d to MADV_DONTNEED, q to quit. Any other key defaults to allocate.\n");
-    int alloc_size = 8 * 1024 * 1024;
+
+    int alloc_size = DEFAULT_ALLOC_SIZE;
     char key_code = 0;
-    void* addrs[10000];
+    void *addrs[10000];
     size_t addr_idx = 0;
     size_t madvised_idx = 0;
+
     while (1) {
         key_code = getch();
         if (key_code == q || key_code == EOF) {
@@ -40,7 +79,7 @@ int main() {
         }
         if (key_code == f || key_code == d) {
             if (madvised_idx < addr_idx) {
-                void * ptr = addrs[madvised_idx++];
+                void *ptr = addrs[madvised_idx++];
                 int advice = MADV_FREE;
                 if (key_code == d) {
                     advice = MADV_DONTNEED;
@@ -53,14 +92,37 @@ int main() {
                 fprintf(stderr, "No memory left to free\n");
             }
         } else {
-            void * ptr = mmap(0, alloc_size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+            void *ptr = mmap(0, alloc_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            if (ptr == MAP_FAILED) {
+                perror("Memory allocation failed");
+                break;
+            }
             addrs[addr_idx++] = ptr;
 
             for (int i = 0; i < alloc_size / sizeof(int); i++) {
-                *(int*)(ptr + i) = 55;
+                ((int *)ptr)[i] = 55;
             }
             fprintf(stderr, "Allocated %p (size %d) and dirtied it\n", ptr, alloc_size);
         }
     }
+}
+
+int main() {
+    // Fetch environment variables for allocation size, number of allocations, and initial sleep
+    char *alloc_env = getenv("ALLOC_SIZE");
+    char *num_allocs_env = getenv("NUM_ALLOCS");
+    char *sleep_env = getenv("INITIAL_SLEEP");
+
+    if (alloc_env && num_allocs_env && sleep_env) {
+        size_t alloc_size = strtoul(alloc_env, NULL, 10);
+        int num_allocs = atoi(num_allocs_env);
+        int initial_sleep = atoi(sleep_env);
+
+        up_front_mode(alloc_size, num_allocs, initial_sleep);
+    } else {
+        interactive_mode();
+    }
+
     return 0;
 }
+

--- a/go_version/Dockerfile
+++ b/go_version/Dockerfile
@@ -1,0 +1,17 @@
+# Start with a golang base image to build the application
+FROM golang:1.23 AS builder
+
+WORKDIR /app
+COPY . .
+
+# Build the Go app
+RUN CGO_ENABLED=0 go build -o gomadv main.go
+
+FROM ubuntu:latest
+
+WORKDIR /root/
+
+COPY --from=builder /app/gomadv .
+
+CMD ["./gomadv"]
+


### PR DESCRIPTION
Both the go and c versions of this now support an "up-front" mode that takes in 3 env vars as arguments and then sleeps forever